### PR TITLE
BIDS.Parser.Variableのバージョンを`1.1.0-beta1`に上げた

### DIFF
--- a/BIDSSMemLib.Variable.Tests/VariableSMemTests.cs
+++ b/BIDSSMemLib.Variable.Tests/VariableSMemTests.cs
@@ -32,6 +32,9 @@ public partial class VariableSMemTests
 				// Data ID
 				.Concat(BitConverter.GetBytes((int)-1))
 
+				// Structure Name (= string.Empty)
+				.Concat(new byte[] { 0 })
+
 				// Structure
 				.Concat(SampleClass.Expected_vUInt16.GetStructureBytes())
 				.Concat(SampleClass.Expected_vInt32.GetStructureBytes())

--- a/BIDSSMemLib.Variable/BIDSSMemLib.Variable.csproj
+++ b/BIDSSMemLib.Variable/BIDSSMemLib.Variable.csproj
@@ -11,6 +11,6 @@
 		<ProjectReference Include="..\TR.SMemIF\TR.SMemIF.csproj" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="BIDS.Parser.Variable" Version="1.0.2" />
+		<PackageReference Include="BIDS.Parser.Variable" Version="1.1.0-beta1" />
 	</ItemGroup>
 </Project>

--- a/BIDSSMemLib.Variable/VariableSMem.cs
+++ b/BIDSSMemLib.Variable/VariableSMem.cs
@@ -127,7 +127,8 @@ public partial class VariableSMem
 		_Members = members.ToList();
 		if (structure is null)
 		{
-			Structure = new(-1, _Members);
+			// Structure Nameは、共有メモリにおいてはSMemNameで代替できるため、記録しない
+			Structure = new(-1, string.Empty, _Members);
 		}
 		else
 		{


### PR DESCRIPTION
BIDS.Parser.Variable (`1.1.0-beta1`) において、外部からの情報共有に対応するため、Structure Nameの共有機能を実装した。

このPRでは、それに対応した修正を行なっている。
なお、SMemNameにてStructure Nameの共有が可能であるため、この実装ではStructure Nameとして`string.Empty`を書き込む形にしている。