### PR TITLE
Linux/MacでSMemIFを使えるようにした

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -19,6 +19,7 @@ jobs:
         os:
           - ubuntu-latest
           - windows-latest
+          - macos-latest
         dotnet-version:
           - '6.0.x'
         project:

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -23,9 +23,7 @@ jobs:
           - '6.0.x'
         project:
           - BIDSSMemLib.Variable.Tests
-        include:
-          - os: windows-latest
-            project: TR.SMemIF.Tests
+          - TR.SMemIF.Tests
 
     steps:
       - uses: actions/checkout@v3

--- a/TR.SMemIF.Tests/TR.SMemIF.Tests.csproj
+++ b/TR.SMemIF.Tests/TR.SMemIF.Tests.csproj
@@ -1,20 +1,20 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+	<PropertyGroup>
+		<TargetFramework>net6.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<LangVersion>9.0</LangVersion>
-    <IsPackable>false</IsPackable>
-  </PropertyGroup>
+		<IsPackable>false</IsPackable>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="NUnit" Version="3.13.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="NUnit" Version="3.13.2" />
+		<PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\TR.SMemIF\TR.SMemIF.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\TR.SMemIF\TR.SMemIF.csproj" />
+	</ItemGroup>
 
 </Project>

--- a/TR.SMemIF.Tests/TR.SMemIF.Tests.csproj
+++ b/TR.SMemIF.Tests/TR.SMemIF.Tests.csproj
@@ -1,20 +1,17 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<TargetFramework>net6.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<LangVersion>9.0</LangVersion>
 		<IsPackable>false</IsPackable>
 	</PropertyGroup>
-
 	<ItemGroup>
 		<PackageReference Include="NUnit" Version="3.13.2" />
 		<PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
 	</ItemGroup>
-
 	<ItemGroup>
 		<ProjectReference Include="..\TR.SMemIF\TR.SMemIF.csproj" />
 	</ItemGroup>
-
 </Project>

--- a/TR.SMemIF.Tests/TR.SMemIF.Tests.csproj
+++ b/TR.SMemIF.Tests/TR.SMemIF.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<LangVersion>9.0</LangVersion>
     <IsPackable>false</IsPackable>

--- a/TR.SMemIF/IRWSemap.cs
+++ b/TR.SMemIF/IRWSemap.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace TR;
+
+public interface IRWSemaphore : IDisposable
+{
+	public void Read(Action act);
+	public void Write(Action act);
+}

--- a/TR.SMemIF/RWSemap.cs
+++ b/TR.SMemIF/RWSemap.cs
@@ -5,7 +5,7 @@ using System.Runtime.CompilerServices;
 namespace TR
 {
 	/// <summary>await可能なR/Wロックを提供する</summary>
-	public class RWSemap : IDisposable
+	public class RWSemap : IDisposable, IRWSemaphore
 	{
 		private const MethodImplOptions MIOpt = (MethodImplOptions)256;//MethodImplOptions.AggressiveInlining;
 

--- a/TR.SMemIF/RWSemap.cs
+++ b/TR.SMemIF/RWSemap.cs
@@ -30,7 +30,7 @@ namespace TR
 		/// <param name="act">読み取り操作</param>
 		/// <returns>成功したかどうか</returns>
 		[MethodImpl(MIOpt)]//関数のインライン展開を積極的にやってもらう.
-		public void Read(Action<object?> act)//net2.0対応のため, object型引数を指定  処理的には不要
+		public void Read(Action act)
 		{
 			while (Want_to_Write > 0)//Writeロック取得待機
 				Thread.Sleep(WAIT_TICK_TIMESPAN);
@@ -38,7 +38,7 @@ namespace TR
 			try
 			{
 				Interlocked.Increment(ref Reading);
-				act?.Invoke(null);
+				act?.Invoke();
 			}
 			finally
 			{
@@ -50,7 +50,7 @@ namespace TR
 		/// <param name="act">書き込み操作</param>
 		/// <returns>成功したかどうか</returns>
 		[MethodImpl(MIOpt)]//関数のインライン展開を積極的にやってもらう.
-		public void Write(Action<object?> act)//net2.0対応のため, object型引数を指定  処理的には不要
+		public void Write(Action act)
 		{
 			try
 			{
@@ -60,7 +60,7 @@ namespace TR
 
 				lock (LockObj)//Writeロック
 				{
-					act?.Invoke(null);
+					act?.Invoke();
 				}
 			}
 			finally

--- a/TR.SMemIF/RWSemap.unix.cs
+++ b/TR.SMemIF/RWSemap.unix.cs
@@ -5,9 +5,9 @@ namespace TR;
 
 public class RWSemap_UNIX : IRWSemaphore
 {
-	private Semaphore Semaphore { get; }
-
 	static readonly private TimeSpan TIMEOUT = new(0, 0, 0, 0, 100);
+
+	private Mutex NamedMutex { get; }
 
 	/// <summary>
 	/// インスタンスを初期化する
@@ -15,7 +15,7 @@ public class RWSemap_UNIX : IRWSemaphore
 	/// <param name="name">使用するリソースの名前</param>
 	public RWSemap_UNIX(string name)
 	{
-		Semaphore = new(0, 1, name + nameof(Semaphore));
+		NamedMutex = new(false, name + "Mutex");
 	}
 
 	public void Read(Action act)
@@ -24,7 +24,7 @@ public class RWSemap_UNIX : IRWSemaphore
 
 		try
 		{
-			Semaphore.WaitOne(TIMEOUT);
+			NamedMutex.WaitOne(TIMEOUT);
 
 			actionTried = true;
 
@@ -33,7 +33,7 @@ public class RWSemap_UNIX : IRWSemaphore
 		finally
 		{
 			if (actionTried)
-				Semaphore.Release();
+				NamedMutex.ReleaseMutex();
 		}
 	}
 
@@ -43,7 +43,7 @@ public class RWSemap_UNIX : IRWSemaphore
 
 		try
 		{
-			Semaphore.WaitOne(TIMEOUT);
+			NamedMutex.WaitOne(TIMEOUT);
 
 			actionTried = true;
 
@@ -52,7 +52,7 @@ public class RWSemap_UNIX : IRWSemaphore
 		finally
 		{
 			if (actionTried)
-				Semaphore.Release();
+				NamedMutex.ReleaseMutex();
 		}
 	}
 
@@ -65,7 +65,8 @@ public class RWSemap_UNIX : IRWSemaphore
 		{
 			if (disposing)
 			{
-				Semaphore.Dispose();
+				NamedMutex.Close();
+				NamedMutex.Dispose();
 			}
 
 			disposedValue = true;

--- a/TR.SMemIF/RWSemap.unix.cs
+++ b/TR.SMemIF/RWSemap.unix.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Threading;
+
+namespace TR;
+
+public class RWSemap_UNIX : IRWSemaphore
+{
+	private Semaphore Semaphore { get; }
+
+	static readonly private TimeSpan TIMEOUT = new(0, 0, 0, 0, 100);
+
+	/// <summary>
+	/// インスタンスを初期化する
+	/// </summary>
+	/// <param name="name">使用するリソースの名前</param>
+	public RWSemap_UNIX(string name)
+	{
+		Semaphore = new(0, 1, name + nameof(Semaphore));
+	}
+
+	public void Read(Action act)
+	{
+		bool actionTried = false;
+
+		try
+		{
+			Semaphore.WaitOne(TIMEOUT);
+
+			actionTried = true;
+
+			act.Invoke();
+		}
+		finally
+		{
+			if (actionTried)
+				Semaphore.Release();
+		}
+	}
+
+	public void Write(Action act)
+	{
+		bool actionTried = false;
+
+		try
+		{
+			Semaphore.WaitOne(TIMEOUT);
+
+			actionTried = true;
+
+			act.Invoke();
+		}
+		finally
+		{
+			if (actionTried)
+				Semaphore.Release();
+		}
+	}
+
+	#region IDisposable Support
+	private bool disposedValue;
+
+	protected virtual void Dispose(bool disposing)
+	{
+		if (!disposedValue)
+		{
+			if (disposing)
+			{
+				Semaphore.Dispose();
+			}
+
+			disposedValue = true;
+		}
+	}
+
+	public void Dispose()
+	{
+		Dispose(disposing: true);
+		GC.SuppressFinalize(this);
+	}
+	#endregion IDisposable Support
+}
+

--- a/TR.SMemIF/SMemIF.cs
+++ b/TR.SMemIF/SMemIF.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.InteropServices;
 
 namespace TR
 {
@@ -20,9 +21,18 @@ namespace TR
 		/// <param name="capacity">共有メモリ空間のキャパシティ</param>
 		public SMemIF(string smem_name, long capacity)
 		{
-			Semap = new RWSemap();
+			if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+			{
+				Semap = new RWSemap();
+				BaseSMemIF = new SemaphorelessSMemIF(smem_name, capacity);
+			}
+			else
+			{
+				SemaphorelessSMemIF_UNIX baseSMemIF = new(smem_name, capacity);
 
-			BaseSMemIF = new SemaphorelessSMemIF(smem_name, capacity);
+				Semap = new RWSemap_UNIX(smem_name);
+				BaseSMemIF = baseSMemIF;
+			}
 		}
 
 		/// <summary>共有メモリ空間の指定の位置から, 指定の型のデータを読み込む</summary>

--- a/TR.SMemIF/SMemIF.cs
+++ b/TR.SMemIF/SMemIF.cs
@@ -5,7 +5,7 @@ namespace TR
 	/// <summary>TargetFramework別にSharedMemoryを提供します.</summary>
 	public class SMemIF : SemaphorelessSMemIF
 	{
-		private RWSemap Semap { get; }
+		private IRWSemaphore Semap { get; }
 
 		/// <summary>インスタンスを初期化する</summary>
 		/// <param name="smem_name">共有メモリ空間の名前</param>

--- a/TR.SMemIF/SMemIF.cs
+++ b/TR.SMemIF/SMemIF.cs
@@ -24,7 +24,7 @@ namespace TR
 		{
 			T retT = default;
 
-			Semap.Read((_) => base.Read(pos, out retT) );
+			Semap.Read(() => base.Read(pos, out retT));
 
 			buf = retT;
 			return true;
@@ -39,7 +39,7 @@ namespace TR
 		/// <returns>読み取りに成功したかどうか</returns>
 		public override bool ReadArray<T>(long pos, T[] buf, int offset, int count) where T : struct
 		{
-			Semap.Read((_) => base.ReadArray(pos, buf, offset, count));
+			Semap.Read(() => base.ReadArray(pos, buf, offset, count));
 
 			return true;
 		}
@@ -53,7 +53,7 @@ namespace TR
 		{
 			T retT = buf;
 
-			Semap.Write((_) => base.Write(pos, ref retT) );
+			Semap.Write(() => base.Write(pos, ref retT));
 
 			return true;
 		}
@@ -67,7 +67,7 @@ namespace TR
 		/// <returns>書き込みに成功したかどうか</returns>
 		public override bool WriteArray<T>(long pos, T[] buf, int offset, int count) where T : struct
 		{
-			Semap.Write((_) => base.WriteArray(pos, buf, offset, count) );
+			Semap.Write(() => base.WriteArray(pos, buf, offset, count));
 
 			return true;
 		}
@@ -89,7 +89,7 @@ namespace TR
 				}
 			}
 		}
-#endregion
+		#endregion
 
 	}
 }

--- a/TR.SMemIF/SemaphorelessSMemIF.unix.cs
+++ b/TR.SMemIF/SemaphorelessSMemIF.unix.cs
@@ -1,0 +1,180 @@
+using System;
+using System.IO;
+using System.IO.MemoryMappedFiles;
+
+namespace TR
+{
+	/// <summary>共有メモリにアクセスする際に, セマフォによる排他制御を呼び出し元で行う場合に使用するクラス</summary>
+	public class SemaphorelessSMemIF_UNIX : SemaphorelessSMemIF_Preprocessing
+	{
+		const long Capacity_Step = 4096;
+		const long CanWriteInOneTime_Bytes = 4096;
+
+		/// <summary>
+		/// Shared Memory Fileが配置されたディレクトリ
+		/// </summary>
+		public static string DefaultSMemDirectory { get; set; } = Path.Combine(Path.GetTempPath(), "TR.SMemIF.SharedMemory");
+
+		/// <summary>
+		/// Shared Memory Fileへのパス
+		/// </summary>
+		public string PathToSMemFile { get; } = "";
+
+		/// <summary>
+		/// Shared Memoryの読み書きに使用するキャパシティ
+		/// </summary>
+		public override long Capacity { get; }
+
+		static long calcNewCapacity(in long inputCapacity)
+			=> (long)Math.Ceiling((float)inputCapacity / Capacity_Step) * Capacity_Step;
+
+		/// <summary>インスタンスを初期化します</summary>
+		/// <param name="smem_name">共有メモリ空間の名前</param>
+		/// <param name="capacity">共有メモリ空間のキャパシティ</param>
+		public SemaphorelessSMemIF_UNIX(string smem_name, long capacity) : base(smem_name, capacity)
+		{
+			Capacity = calcNewCapacity(capacity);
+
+			if (int.MaxValue < Capacity)
+				throw new ArgumentOutOfRangeException(nameof(capacity), "cannot use more than int.MaxValue");
+
+			string dirPath = DefaultSMemDirectory;
+			if (!Directory.Exists(dirPath))
+				Directory.CreateDirectory(dirPath);
+
+			PathToSMemFile = Path.Combine(dirPath, smem_name);
+
+			if (!File.Exists(PathToSMemFile))
+			{
+				using var _ = File.Create(PathToSMemFile, (int)Capacity);
+				IsNewlyCreated = true;
+			}
+		}
+
+		/// <summary>共有メモリ空間の指定の位置から, 指定の型のデータを読み込む</summary>
+		/// <typeparam name="T">読み込みたい型</typeparam>
+		/// <param name="pos">読み込む位置 [bytes]</param>
+		/// <param name="buf">読み込むデータ</param>
+		/// <returns>読み込みに成功したかどうか  (例外は捕捉されません)</returns>
+		public override bool Read<T>(long pos, out T buf) where T : struct
+		{
+			if (!base.Read(pos, out buf))
+				return false;
+
+			using MemoryMappedFile mmf = MemoryMappedFile.CreateFromFile(PathToSMemFile, FileMode.Open, null, Capacity);
+			using MemoryMappedViewAccessor mmva = mmf.CreateViewAccessor(0, Capacity);
+			if (!mmva.CanRead)
+				return false;
+
+			mmva.Read(pos, out buf);
+
+			return true;
+		}
+
+		/// <summary>SMemから連続的に値を読み取ります</summary>
+		/// <typeparam name="T">値の型</typeparam>
+		/// <param name="pos">読み込む位置 [bytes]</param>
+		/// <param name="buf">読み取り結果を格納する配列</param>
+		/// <param name="offset">配列内で書き込みを開始する位置</param>
+		/// <param name="count">読み取りを行う数</param>
+		/// <returns>読み取りに成功したかどうか</returns>
+		public override bool ReadArray<T>(long pos, T[] buf, int offset, int count) where T : struct
+		{
+			if (!base.ReadArray(pos, buf, offset, count))
+				return false;
+
+			using MemoryMappedFile mmf = MemoryMappedFile.CreateFromFile(PathToSMemFile, FileMode.Open, null, Capacity);
+			using MemoryMappedViewAccessor mmva = mmf.CreateViewAccessor(0, Capacity);
+			if (!mmva.CanRead)
+				return false;
+
+			mmva.ReadArray(pos, buf, offset, count);
+
+			return true;
+		}
+
+		/// <summary>共有メモリ空間の指定の位置に指定のデータを書き込む</summary>
+		/// <typeparam name="T">データの型</typeparam>
+		/// <param name="pos">書き込む位置 [bytes]</param>
+		/// <param name="buf">書き込むデータ</param>
+		/// <returns>書き込みに成功したかどうか</returns>
+		public override bool Write<T>(long pos, ref T buf) where T : struct
+		{
+			if (!base.Write(pos, ref buf))
+				return false;
+
+			using MemoryMappedFile mmf = MemoryMappedFile.CreateFromFile(PathToSMemFile, FileMode.Open, null, Capacity);
+			using MemoryMappedViewAccessor mmva = mmf.CreateViewAccessor(0, Capacity);
+			if (!mmva.CanWrite)
+				return false;
+
+			mmva.Write(pos, ref buf);
+
+			return true;
+		}
+
+		/// <summary>SMemに連続した値を書き込みます</summary>
+		/// <typeparam name="T">書き込む値の型</typeparam>
+		/// <param name="pos">書き込みを開始するSMem内の位置 [bytes]</param>
+		/// <param name="buf">SMemに書き込む配列</param>
+		/// <param name="offset">配列内で書き込みを開始する位置</param>
+		/// <param name="count">書き込む要素数</param>
+		/// <returns>書き込みに成功したかどうか</returns>
+		public override bool WriteArray<T>(long pos, T[] buf, int offset, int count) where T : struct
+		{
+			if (!base.WriteArray(pos, buf, offset, count))
+				return false;
+
+			long elemBytes = getElemSize<T>();
+			int canWriteInOneTime = (int)(CanWriteInOneTime_Bytes / elemBytes);
+			long posStep = elemBytes * canWriteInOneTime;
+
+			using MemoryMappedFile mmf = MemoryMappedFile.CreateFromFile(PathToSMemFile, FileMode.Open, null, Capacity);
+			using MemoryMappedViewAccessor mmva = mmf.CreateViewAccessor(0, Capacity);
+			if (!mmva.CanWrite)
+				return false;
+
+			while (count > 0)
+			{
+				int write_count = count > canWriteInOneTime ? canWriteInOneTime : count;
+
+				mmva.WriteArray(pos, buf, offset, write_count);
+
+				offset += canWriteInOneTime;
+				count -= canWriteInOneTime;
+				pos += posStep;
+			}
+
+			return true;
+		}
+
+		#region IDisposable Support
+		/// <summary>リソースの解放が完了したかどうか</summary>
+		protected bool disposedValue = false;
+
+		/// <summary>保持しているリソースを解放する</summary>
+		/// <param name="disposing">Managedリソースも解放するかどうか</param>
+		protected virtual void Dispose(bool disposing)
+		{
+			disposedValue = true;
+
+			if (!disposedValue)
+			{
+				if (disposing)
+				{
+				}
+
+				disposedValue = true;
+			}
+		}
+
+		/// <summary>保持しているリソースを解放する</summary>
+		public override void Dispose()
+		{
+			// Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+			Dispose(disposing: true);
+			GC.SuppressFinalize(this);
+		}
+		#endregion
+	}
+}

--- a/TR.SMemIF/TR.SMemIF.csproj
+++ b/TR.SMemIF/TR.SMemIF.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<TargetFramework>netstandard2.0</TargetFramework>
-		<LangVersion>9.0</LangVersion>
+		<LangVersion>10.0</LangVersion>
 		<Nullable>enable</Nullable>
 		<AssemblyName>TR.SMemIF</AssemblyName>
 		<RootNamespace>TR</RootNamespace>


### PR DESCRIPTION
Windows以外ではインメモリなMemoryMappedFileを作成できないため、ストレージにファイルを作成し、それをMemoryにMapすることで共有メモリの代わりとした。

なお、複数プロセスから一つのファイルに同時にアクセスするとエラーが出るため、Mutexを用いた排他制御を実装した。

このPRでは、ReaderとWriterでMutexを共有していたり、ファイル競合を無くすために毎度毎度ファイルのOpen / Closeを行うなど、非常に非効率的な実装になってしまっている。
この点については、将来的に解決したいと思いつつ、正直このままでも良いのではとか思い始めてる。